### PR TITLE
Update background.js

### DIFF
--- a/background.js
+++ b/background.js
@@ -17,6 +17,9 @@ chrome.webRequest.onBeforeRequest.addListener(
             "*://www.rbsonline.com.br/cdn/scripts/paywall.min.js*",
 
             "*://correio.rac.com.br/includes/js/novo_cp/fivewall.js*"
+            
+            "*://www.jornalnh.com.br/includes/js/paywall.js*"
+            "*://blockv2.fivewall.com.br/*"
         ],
         types: ["script"]
     },

--- a/background.js
+++ b/background.js
@@ -20,6 +20,10 @@ chrome.webRequest.onBeforeRequest.addListener(
             
             "*://www.jornalnh.com.br/includes/js/paywall.js*"
             "*://blockv2.fivewall.com.br/*"
+            
+            "*://www.portalnews.com.br/includes/js/paywall.js*"
+            "*://www.tribunadeindaia.com.br/includes/js/paywall.js*"
+
         ],
         types: ["script"]
     },


### PR DESCRIPTION
Aqui, com o uso do adblock, consigo remover o paywall do Jornal NH bloqueando esses dois scripts:

http://blockv2.fivewall.com.br/?token=jornalnh&amp;cache=cache&amp;_fw=57a0cfd311663*
http://www5.smartadserver.com/config.js?nwid=1846*