### PR TITLE
Atualizando o paywall da Gazeta do Povo

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -17,8 +17,7 @@ chrome.webRequest.onBeforeRequest.addListener(
       "*://cdn.tinypass.com/api/tinypass.min.js",
 
       // Gazeta do Povo
-      "*://*.gazetadopovo.com.br/conta/public/js/connect_api.js*",
-      "*://*.gazetadopovo.com.br/conta/going/api/paywall/*",
+      "*://*.gazetadopovo.com.br/loader/v1/logan_full_toolbar.js*"
 
       // Zero Hora
       "*://zh.clicrbs.com.br/it/js/paid-content-config.js*",

--- a/src/background.js
+++ b/src/background.js
@@ -17,7 +17,7 @@ chrome.webRequest.onBeforeRequest.addListener(
       "*://cdn.tinypass.com/api/tinypass.min.js",
 
       // Gazeta do Povo
-      "*://*.gazetadopovo.com.br/loader/v1/logan_full_toolbar.js*"
+      "*://*.gazetadopovo.com.br/loader/v1/logan_full_toolbar.js*",
 
       // Zero Hora
       "*://zh.clicrbs.com.br/it/js/paid-content-config.js*",


### PR DESCRIPTION
Testei apenas bloqueando a url em questão via uBlock. Me parece remover o paywall e não notei outra consequência mais séria para o usuário sem login.